### PR TITLE
Derive days-until-empty from real tank capacity, not a hard-coded 510 L

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ data:
 
 ## Upgrading
 
+### To 1.3.1
+
+Days Until Empty had two implementations, and the one the sensor actually used fell back to a hard-coded 510 L rather than your tank's real capacity. It only showed on a fresh install, before any consumption history exists, where it made the estimate roughly twice as optimistic as intended. Once history exists the figure was always correct and is unchanged.
+
 ### To 1.3.0
 
 - Seasonal Oil Consumption now works. It previously reported `unknown` on most polls and could only ever populate one season. Existing installs start reporting straight away, but the remaining seasons fill in as history accrues: the fix stops data being discarded, it cannot recover what was already thrown away.

--- a/custom_components/boilerjuice/coordinator.py
+++ b/custom_components/boilerjuice/coordinator.py
@@ -933,10 +933,6 @@ class BoilerJuiceDataUpdateCoordinator(DataUpdateCoordinator):
                 data["total_consumption_usable_kwh"] = (
                     self._total_consumption_usable_kwh
                 )
-                data["daily_consumption_usable_liters"] = (
-                    self._daily_consumption_usable_liters
-                )
-                data["days_until_empty"] = self._calculate_days_until_empty(data)
 
                 # Recalculate rolling average on every coordinator run (not just when consumption detected)
                 # This allows old incorrect data to naturally age out after 7 days
@@ -963,6 +959,15 @@ class BoilerJuiceDataUpdateCoordinator(DataUpdateCoordinator):
                         )
                         if day_start >= cutoff_date
                     ]
+
+                # Everything below is derived from the rolling average, so it is
+                # published after the recalculation above rather than before it.
+                # Set earlier, these carried the previous run's figures on any
+                # poll where no consumption was detected.
+                data["daily_consumption_usable_liters"] = (
+                    self._daily_consumption_usable_liters
+                )
+                data["days_until_empty"] = self._calculate_days_until_empty(data)
 
                 # Seasonal stats are recalculated on every refresh, not only when
                 # consumption is detected. `data` is rebuilt from the scrape each

--- a/custom_components/boilerjuice/manifest.json
+++ b/custom_components/boilerjuice/manifest.json
@@ -13,6 +13,6 @@
   "quality_scale": "silver",
   "requirements": ["aiohttp>=3.8.0", "beautifulsoup4>=4.12.0"],
   "ssdp": [],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "zeroconf": []
 }

--- a/custom_components/boilerjuice/sensor.py
+++ b/custom_components/boilerjuice/sensor.py
@@ -319,31 +319,18 @@ class BoilerJuiceDaysUntilEmptySensor(BoilerJuiceSensor):
 
     @property
     def native_value(self) -> float | None:
-        """Return the state of the sensor."""
+        """Return the estimate calculated by the coordinator.
+
+        This used to recompute the estimate here, which meant two copies of
+        the same logic. They drifted: this one fell back to a hard-coded
+        510 L "usable capacity" via a key the scrape never writes, so on a
+        fresh install with no consumption history it estimated against 510 L
+        no matter the real tank size.
+        """
         if not self._coordinator.data:
             return None
 
-        usable_volume = self._coordinator.data.get("usable_volume_litres")
-        if usable_volume is None:
-            return None
-
-        # If we have actual consumption data, use it
-        daily_consumption = self._coordinator.data.get(
-            "daily_consumption_usable_liters"
-        )
-        if daily_consumption and daily_consumption > 0:
-            return round(usable_volume / daily_consumption, 1)
-
-        # Otherwise, estimate based on usable capacity
-        usable_capacity = self._coordinator.data.get(
-            "usable_capacity_litres", 510
-        )  # Default to 510L if not specified
-        if usable_capacity:
-            # Assume average daily consumption of 2% of usable capacity
-            estimated_daily_consumption = usable_capacity * 0.02
-            return round(usable_volume / estimated_daily_consumption, 1)
-
-        return None
+        return self._coordinator.data.get("days_until_empty")
 
 
 class BoilerJuiceOilLevelSensor(BoilerJuiceSensor):


### PR DESCRIPTION
Bumps to **1.3.1**. Follow-up to #5, found while checking the live values in Home Assistant after the 1.3.0 release.

## The bug

`Days Until Empty` had two implementations: the coordinator computed it into `data["days_until_empty"]`, and `BoilerJuiceDaysUntilEmptySensor` recomputed it independently. Nothing read the coordinator's value, and the two had drifted.

The sensor's copy fell back to `data["usable_capacity_litres"]` — a key the scrape never writes — defaulting to a hard-coded 510 L. On a fresh install, before any consumption history exists, it estimated against 510 L regardless of the actual tank:

| | Daily estimate | Days until empty |
|---|---|---|
| Before (2% of hard-coded 510 L) | 10.2 L/day | 59.8 |
| After (2% of scraped 1100 L) | 22.0 L/day | 27.7 |

About 2.2x too optimistic, on a tank holding 610 L. Once consumption history exists the fallback isn't reached, so the figure was always correct there — verified against the live tank, where 610 L at 1.2505 L/day still gives **487.8 days**, unchanged.

This is the same class of defect as the `level_percentage` key fixed in #5: a fallback reading a key nothing writes. It survived that fix precisely because the logic was duplicated — I corrected the coordinator's copy, which nothing consumed. Fixing it in one place this time, by deleting the duplicate.

## Also

`daily_consumption_usable_liters` and `days_until_empty` are now published *after* the rolling average is recalculated. Set beforehand, they carried the previous run's figures on any poll where no consumption was detected — a one-hour lag whenever old days aged out of the window.

## Verification

Against stubbed HA modules, plus the live instance for the current-value check:

- live tank (610 L, 1.2505 L/day) → 487.8 days, matching what HA shows now
- fresh install (610 L, no history, 1100 L tank) → 27.7 days, was 59.8
- no capacity scraped → still returns `None`
- the 1.3.0 suites all still pass: seasonal, spread conservation, timezone migration, config-flow outcomes, and the steady-state rate settling at exactly 10.00 L/day

🤖 Generated with [Claude Code](https://claude.com/claude-code)