### PR TITLE
Describe a page we cannot read, and keep diagnostics working when setup fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ Other behaviour worth knowing:
   the seasonal sensor has no autumn to report. When that drop arrives the
   litres are spread back over every day since the last one, so the days in
   between fill in retroactively rather than being lost.
+- **A page we cannot read is described, not quoted.** When the tanks page
+  or a tank page arrives in a shape the parser does not recognise, the
+  warning carries a summary of the page: its size, how many forms, links
+  and tank links it holds, and whether it matches a known interstitial such
+  as a Cloudflare challenge or a maintenance notice. Page HTML is never
+  logged, so the summary is counts and fixed words only, and is safe to
+  paste into an issue.
 - **Diagnostics say where the history reaches.** `history_span` and
   `history_rows_by_month` in the diagnostics download show which months hold
   data. A month missing from the middle is history that went away; months

--- a/custom_components/boilerjuice/diagnostics.py
+++ b/custom_components/boilerjuice/diagnostics.py
@@ -98,8 +98,38 @@ def _rows_by_month(tracker: TankTracker) -> dict[str, int]:
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: BoilerJuiceConfigEntry
 ) -> dict[str, Any]:
-    """Return diagnostics for one BoilerJuice account."""
-    coordinator = entry.runtime_data.coordinator
+    """Return diagnostics for one BoilerJuice account.
+
+    An entry that failed to set up has no runtime data, and asking for it
+    raised AttributeError, which Home Assistant served as HTTP 500. The
+    download was therefore unavailable at the one moment anybody wants
+    it: while the integration is stuck in setup_retry. What the config
+    entry knows is reported on its own in that case.
+    """
+    runtime = getattr(entry, "runtime_data", None)
+    if runtime is None:
+        return {
+            "config_entry_id": entry.entry_id,
+            "data": {
+                "integration": {
+                    "config_entry_version": entry.version,
+                    "storage_version": STORAGE_VERSION,
+                    "source": entry.source,
+                    "tank_is_pinned": bool(entry.data.get(CONF_TANK_ID)),
+                    "tanks_are_filtered": bool(entry.options.get(CONF_TANKS)),
+                },
+                "update_health": {
+                    "set_up": False,
+                    "state": str(entry.state),
+                    # The setup failure's own message. Parse failures carry
+                    # the page shape, which is counts and fixed words only.
+                    "reason": entry.reason,
+                },
+                "tanks": [],
+            },
+        }
+
+    coordinator = runtime.coordinator
     published = coordinator.data or {}
 
     return {

--- a/custom_components/boilerjuice/manifest.json
+++ b/custom_components/boilerjuice/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "beautifulsoup4==4.15.0"
   ],
-  "version": "2.0.0-beta.3"
+  "version": "2.0.0-beta.4"
 }

--- a/custom_components/boilerjuice/parser.py
+++ b/custom_components/boilerjuice/parser.py
@@ -231,6 +231,50 @@ def looks_like_empty_tank_list(soup: BeautifulSoup) -> bool:
     return False
 
 
+# Vendor strings that identify an interstitial rather than the page asked
+# for. Matched case-insensitively against the document, and reported only
+# as which one matched: a fixed list of our own words, never page content.
+_INTERSTITIAL_MARKERS = {
+    "cloudflare": ("cf-browser-verification", "cf-challenge", "just a moment"),
+    "blocked": ("attention required", "access denied", "request blocked"),
+    "rate_limited": ("too many requests", "rate limit"),
+    "maintenance": ("under maintenance", "temporarily unavailable"),
+}
+
+
+def describe_page_shape(html: str) -> dict[str, Any]:
+    """Describe an unexpected page without reproducing any of it.
+
+    A page we cannot read is invisible by design: page HTML is never
+    logged, at any level, because it carries the account. That left a
+    layout change, a Cloudflare challenge and a maintenance page looking
+    identical from the outside, which is no way to diagnose an install
+    you cannot reach.
+
+    Everything below is a count, a boolean, or one of our own fixed
+    words. No text from the page is copied into the result.
+    """
+    lowered = html.lower()
+    soup = BeautifulSoup(html, "html.parser")
+
+    interstitial = sorted(
+        name
+        for name, markers in _INTERSTITIAL_MARKERS.items()
+        if any(marker in lowered for marker in markers)
+    )
+
+    return {
+        "bytes": len(html),
+        "is_html": soup.find("html") is not None or soup.find("body") is not None,
+        "forms": len(soup.find_all("form")),
+        "password_inputs": len(soup.find_all("input", {"type": "password"})),
+        "links": len(soup.find_all("a")),
+        "tank_links": len(soup.find_all("a", href=_TANK_LINK_RE)),
+        "scripts": len(soup.find_all("script")),
+        "looks_like_interstitial": interstitial,
+    }
+
+
 def parse_tank_ids(html: str) -> list[str]:
     """Return the validated tank ids linked from the tanks listing page.
 
@@ -257,9 +301,12 @@ def parse_tank_ids(html: str) -> list[str]:
     if tank_ids or looks_like_empty_tank_list(soup):
         return tank_ids
 
+    # The shape goes in the message so the reason a user reads in the UI
+    # says what kind of page arrived, not merely that one did.
     raise BoilerJuiceParseError(
         "The BoilerJuice tanks page listed no tanks and did not look like an "
-        "empty account; refusing to treat it as proof that the tanks are gone"
+        "empty account; refusing to treat it as proof that the tanks are gone "
+        f"(page shape: {describe_page_shape(html)})"
     )
 
 
@@ -453,7 +500,8 @@ def parse_tank_page(html: str, tank_id: str) -> TankReading:
     if not reading.has_measurement:
         raise BoilerJuiceParseError(
             "The BoilerJuice tank page contained neither an oil level nor an "
-            "oil volume; refusing to treat it as a reading"
+            f"oil volume; refusing to treat it as a reading "
+            f"(page shape: {describe_page_shape(html)})"
         )
 
     return reading

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -196,3 +196,26 @@ async def test_diagnostics_report_no_span_without_history(
 
     assert tank["history_span"] is None
     assert tank["history_rows_by_month"] == {}
+
+
+async def test_diagnostics_work_while_setup_is_failing(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """The one moment anybody wants the download is when setup is stuck.
+
+    Reading runtime_data off an entry that never finished setting up
+    raised AttributeError, which Home Assistant served as HTTP 500.
+    """
+    mock_site(aioclient_mock, tank_html=load_fixture("tank_current.html"))
+    entry = await setup_account(hass, aioclient_mock)
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    report = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert report["data"]["update_health"]["set_up"] is False
+    assert report["data"]["tanks"] == []
+    assert json.dumps(report)
+
+    for secret in SECRETS:
+        assert secret not in json.dumps(report), f"diagnostics leaked {secret!r}"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,7 +8,10 @@ then recorded as the whole tank being burnt in one hour.
 
 from __future__ import annotations
 
+import json
+
 import pytest
+from custom_components.boilerjuice import parser
 from custom_components.boilerjuice.errors import (
     BoilerJuiceAuthError,
     BoilerJuiceParseError,
@@ -476,3 +479,84 @@ def test_a_malformed_entry_does_not_hide_a_good_one_after_it() -> None:
 
     assert reading.manufacturer == "Titan"
     assert reading.model == "ES2500"
+
+
+# --- describing a page we cannot read -------------------------------------
+
+CHALLENGE = """
+<html><head><title>Just a moment...</title></head>
+<body><div class="cf-browser-verification">Checking your browser</div>
+<script>window._cf_chl_opt={};</script></body></html>
+"""
+
+SECRET_PAGE = """
+<html><body>
+  <h1>Welcome back, Wilhelmina Bracegirdle</h1>
+  <p>will@together.agency</p>
+  <p>Tank 998877 at 12 Sycamore Lane, Tunbridge Wells</p>
+  <input type="hidden" name="authenticity_token" value="s3cr3t-csrf-value">
+</body></html>
+"""
+
+
+def test_the_shape_of_a_challenge_page_is_recognisable() -> None:
+    """A layout change and a bot challenge used to look identical."""
+    shape = parser.describe_page_shape(CHALLENGE)
+
+    assert shape["looks_like_interstitial"] == ["cloudflare"]
+    assert shape["tank_links"] == 0
+    assert shape["is_html"] is True
+
+
+def test_the_shape_of_a_real_tanks_page_names_no_interstitial() -> None:
+    shape = parser.describe_page_shape(load_fixture("tanks_list.html"))
+
+    assert shape["looks_like_interstitial"] == []
+    assert shape["tank_links"] > 0
+
+
+def test_the_shape_carries_no_page_content() -> None:
+    """Page HTML is never reproduced, at any level. Counts only.
+
+    The whole point of the describer is to be safe to log and to paste
+    into an issue, so nothing from the document may survive into it.
+    """
+    shape = parser.describe_page_shape(SECRET_PAGE)
+    serialised = json.dumps(shape)
+
+    for secret in (
+        "Wilhelmina",
+        "Bracegirdle",
+        "will@together.agency",
+        "998877",
+        "Sycamore",
+        "Tunbridge",
+        "s3cr3t-csrf-value",
+        "authenticity_token",
+    ):
+        assert secret not in serialised, f"the page shape leaked {secret!r}"
+
+    # Only counts, booleans and our own fixed words.
+    assert set(shape) == {
+        "bytes",
+        "is_html",
+        "forms",
+        "password_inputs",
+        "links",
+        "tank_links",
+        "scripts",
+        "looks_like_interstitial",
+    }
+    for key, value in shape.items():
+        if key == "looks_like_interstitial":
+            assert set(value) <= set(parser._INTERSTITIAL_MARKERS)
+        else:
+            assert isinstance(value, (int, bool))
+
+
+def test_an_unreadable_tanks_page_reports_its_shape() -> None:
+    """The reason a user reads in the UI should say what arrived."""
+    with pytest.raises(BoilerJuiceParseError) as caught:
+        parse_tank_ids(CHALLENGE)
+
+    assert "cloudflare" in str(caught.value)


### PR DESCRIPTION
A live install on `v2.0.0-beta.3` stopped reading its tanks page at 14:34, having worked since 13:43. Signing in through a browser works. `parser.py`, `client.py` and `models.py` are byte-identical between beta.1 and beta.3, so nothing in the scraping path moved.

The log says the page listed no tanks and did not look like an empty account, which is the guard working, and then says nothing else. Page HTML is never logged, at any level, because it carries the account. That is the right rule, and it left a redesign, a Cloudflare challenge, a rate-limit page and a maintenance notice all looking identical from the outside, with no way to tell them apart on an install I cannot reach.

## Describing the page without quoting it

`describe_page_shape` reports shape and no content:

```
bytes, is_html, forms, password_inputs, links, tank_links, scripts,
looks_like_interstitial: ["cloudflare" | "blocked" | "rate_limited" | "maintenance"]
```

Every value is a count, a boolean, or one of our own fixed words. A test feeds it a page carrying a name, an email address, a tank id, a street address and a CSRF token, and asserts that none of them survive into the result, and that the key set is exactly the eight above. The summary is therefore safe to log and safe to paste into an issue.

Both parse failures carry it now, so the reason a user reads in the UI says what kind of page arrived.

## Diagnostics returned HTTP 500 during a setup failure

Reading `runtime_data` off an entry that never finished setting up raised `AttributeError`, which Home Assistant serves as a 500. The download was unavailable at the one moment anybody wants it. It now reports what the config entry knows, including the setup failure's own reason, which for a parse failure carries the page shape.

## Tests

519 pass on Home Assistant 2026.9.0 / Python 3.14; 518 pass and 1 skips on 2025.2.5 / Python 3.13. Ruff, ruff format and mypy clean. The five tests added here fail on the parent commit, verified by stashing `custom_components/` and re-running.

## What this does not do

It does not fix the outage. It makes the next log line say what the page is, which is the thing currently missing. If it turns out to be a bot challenge, what to do about that is a separate decision and not one to make quietly in a patch.

Version bumped to `2.0.0-beta.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YM6JoVZhyhpPrURZdGm1k

---
_Generated by [Claude Code](https://claude.ai/code/session_017YM6JoVZhyhpPrURZdGm1k)_