### PR TITLE
Read the full BoilerJuice page before deciding it is a JavaScript app

### DIFF
--- a/custom_components/boilerjuice/client.py
+++ b/custom_components/boilerjuice/client.py
@@ -372,9 +372,7 @@ class BoilerJuiceClient:
 
     async def async_list_tank_ids(self) -> list[str]:
         """Return every tank id on the account, in page order."""
-        body = await self._async_get_tank_document(
-            TANKS_URL, "BoilerJuice tanks page"
-        )
+        body = await self._async_get_tank_document(TANKS_URL, "BoilerJuice tanks page")
         return parse_tank_ids(body)
 
     async def async_fetch_tank(self, tank_id: str | None = None) -> TankReading:

--- a/custom_components/boilerjuice/client.py
+++ b/custom_components/boilerjuice/client.py
@@ -29,6 +29,9 @@ from .errors import (
 )
 from .models import TankReading
 from .parser import (
+    looks_like_javascript_shell,
+    looks_like_json,
+    looks_like_json_sign_in,
     looks_like_login_page,
     parse_price,
     parse_tank_ids,
@@ -143,15 +146,28 @@ class BoilerJuiceClient:
 
     @staticmethod
     async def _read_text(response: aiohttp.ClientResponse, description: str) -> str:
-        """Read a bounded amount of body text from `response`."""
-        raw = await response.content.read(MAX_RESPONSE_BYTES + 1)
+        """Read a bounded amount of body text from `response`.
+
+        Must use ``response.read()``, not ``response.content.read(n)``.
+        On the live site the body is chunked and gzipped; a sized stream
+        read returned only the ``<head>`` — scripts, no forms, no tank
+        links — which we then described as a JavaScript app rewrite.
+        ``read()`` waits for the decoded payload, then we enforce the cap.
+        """
+        raw = await response.read()
         if len(raw) > MAX_RESPONSE_BYTES:
             raise BoilerJuiceParseError(
                 f"The {description} was larger than {MAX_RESPONSE_BYTES} bytes"
             )
         return raw.decode(response.charset or "utf-8", errors="replace")
 
-    async def _async_get(self, url: str, description: str) -> tuple[str, str]:
+    async def _async_get(
+        self,
+        url: str,
+        description: str,
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[str, str]:
         """GET `url`, returning (body, final URL).
 
         Redirects are followed by hand, one validated hop at a time. aiohttp
@@ -164,7 +180,9 @@ class BoilerJuiceClient:
         target = yarl.URL(url)
         for _ in range(MAX_REDIRECTS + 1):
             try:
-                async with self.session.get(target, allow_redirects=False) as response:
+                async with self.session.get(
+                    target, allow_redirects=False, headers=headers
+                ) as response:
                     if response.status in REDIRECT_STATUSES:
                         location = response.headers.get("Location")
                     else:
@@ -282,33 +300,81 @@ class BoilerJuiceClient:
             )
         return target
 
-    async def _async_get_signed_in(self, url: str, description: str) -> str:
+    async def _async_get_signed_in(
+        self, url: str, description: str, *, accept_json: bool = False
+    ) -> str:
         """GET `url` while signed in, renewing the session once if it lapsed.
 
         BoilerJuice expires sessions on its own schedule, so one silent
         re-sign-in is normal operation rather than an error worth surfacing.
+
+        A lapsed HTML session comes back as the sign-in page. A lapsed
+        JSON session comes back as HTTP 401. Both are retried once.
         """
+        headers = {"Accept": "application/json"} if accept_json else None
+
         if not self._signed_in:
             await self._async_sign_in()
 
-        body, _ = await self._async_get(url, description)
-        if not looks_like_login_page(body):
+        body, expired = await self._async_signed_in_once(url, description, headers)
+        if not expired:
             return body
 
         _LOGGER.debug("The BoilerJuice session lapsed; signing in again")
         self._signed_in = False
         await self._async_sign_in()
 
-        body, _ = await self._async_get(url, description)
-        if looks_like_login_page(body):
+        body, expired = await self._async_signed_in_once(url, description, headers)
+        if expired:
             raise BoilerJuiceAuthError(
-                "BoilerJuice kept returning the sign-in page after a fresh login"
+                "BoilerJuice kept refusing access after a fresh login"
             )
         return body
 
+    async def _async_signed_in_once(
+        self,
+        url: str,
+        description: str,
+        headers: dict[str, str] | None,
+    ) -> tuple[str, bool]:
+        """GET once. Return (body, True) when the session looks expired."""
+        try:
+            body, _ = await self._async_get(url, description, headers=headers)
+        except BoilerJuiceAuthError:
+            return "", True
+        return body, looks_like_login_page(body) or looks_like_json_sign_in(body)
+
+    async def _async_get_tank_document(self, url: str, description: str) -> str:
+        """GET a tank document as HTML, falling back to the JSON twin.
+
+        Asking the HTML path for ``Accept: application/json`` is a 500 on
+        a signed-in session. The HTML page still carries the tanks. When
+        that page is only a JavaScript shell, the same path with ``.json``
+        is the API — and that request is allowed to ask for JSON.
+        """
+        body = await self._async_get_signed_in(url, description)
+        if looks_like_json(body) or not looks_like_javascript_shell(body):
+            return body
+        if url.endswith(".json"):
+            return body
+        json_url = f"{url}.json"
+        try:
+            json_body = await self._async_get_signed_in(
+                json_url, description, accept_json=True
+            )
+        except (
+            BoilerJuiceAuthError,
+            BoilerJuiceConnectionError,
+            BoilerJuiceParseError,
+        ):
+            return body
+        return json_body if looks_like_json(json_body) else body
+
     async def async_list_tank_ids(self) -> list[str]:
         """Return every tank id on the account, in page order."""
-        body = await self._async_get_signed_in(TANKS_URL, "BoilerJuice tanks page")
+        body = await self._async_get_tank_document(
+            TANKS_URL, "BoilerJuice tanks page"
+        )
         return parse_tank_ids(body)
 
     async def async_fetch_tank(self, tank_id: str | None = None) -> TankReading:
@@ -330,7 +396,7 @@ class BoilerJuiceClient:
         if canonical is None:
             raise BoilerJuiceParseError("Refusing to use a non-numeric tank id")
 
-        body = await self._async_get_signed_in(
+        body = await self._async_get_tank_document(
             f"{TANKS_URL}/{canonical}/edit", "BoilerJuice tank page"
         )
         return parse_tank_page(body, canonical)

--- a/custom_components/boilerjuice/manifest.json
+++ b/custom_components/boilerjuice/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "beautifulsoup4==4.15.0"
   ],
-  "version": "2.0.0-beta.4"
+  "version": "2.0.0-beta.5"
 }

--- a/custom_components/boilerjuice/parser.py
+++ b/custom_components/boilerjuice/parser.py
@@ -1,4 +1,4 @@
-"""Turning BoilerJuice HTML into validated readings.
+"""Turning BoilerJuice HTML or JSON into validated readings.
 
 Pure functions: no network, no clock, no Home Assistant. Everything here
 either produces a value that passed validation or leaves the field out.
@@ -286,7 +286,14 @@ def parse_tank_ids(html: str) -> list[str]:
 
     This is the same mistake the tank page used to make, one page earlier:
     treating an unreadable response as a confident measurement of nothing.
+
+    The listing is now a JavaScript app that fetches JSON. A body that
+    looks like JSON is read as JSON; HTML is still accepted so an older
+    page, or a test fixture, keeps working.
     """
+    if looks_like_json(html):
+        return _parse_tank_ids_json(html)
+
     soup = BeautifulSoup(html, "html.parser")
     tank_ids: list[str] = []
     for link in soup.find_all("a", href=_TANK_LINK_RE):
@@ -308,6 +315,313 @@ def parse_tank_ids(html: str) -> list[str]:
         "empty account; refusing to treat it as proof that the tanks are gone "
         f"(page shape: {describe_page_shape(html)})"
     )
+
+
+# Keys the JSON API has used, or that a Rails-style tank object is likely
+# to use. Tried in order; the first value that survives validation wins.
+# A renamed field that is not on this list costs a parse error with the
+# JSON shape in the message, not a guessed zero.
+_JSON_ID_KEYS = ("id", "tank_id")
+_JSON_LEVEL_KEYS = (
+    "level_percentage",
+    "oil_level_percentage",
+    "usable_level_percentage",
+    "total_level_percentage",
+    "usable_percentage",
+    "total_percentage",
+    "percentage",
+    "percent",
+    "oil_level",
+    "level",
+)
+_JSON_VOLUME_KEYS = (
+    "volume_litres",
+    "current_volume_litres",
+    "usable_volume_litres",
+    "remaining_litres",
+    "oil_volume",
+    "litres",
+    "liters",
+    "volume",
+)
+_JSON_CAPACITY_KEYS = ("capacity_litres", "tank_size", "capacity", "size")
+_JSON_HEIGHT_KEYS = ("internal_height", "height_cm", "height")
+_JSON_NAME_KEYS = ("name", "tank_name")
+_JSON_SHAPE_KEYS = ("shape", "tank_shape")
+_JSON_OIL_TYPE_KEYS = ("oil_type", "oilType")
+_JSON_MODEL_KEYS = ("model", "Description", "description")
+_JSON_MANUFACTURER_KEYS = ("manufacturer", "Brand", "brand")
+_JSON_MODEL_ID_KEYS = ("model_id", "tank_model_id")
+_JSON_LIST_KEYS = ("tanks", "user_tanks", "data", "results")
+
+
+def looks_like_json(body: str) -> bool:
+    """Return True when `body` is more likely JSON than HTML."""
+    stripped = body.lstrip("\ufeff \t\r\n")
+    return stripped.startswith("{") or stripped.startswith("[")
+
+
+def looks_like_javascript_shell(html: str) -> bool:
+    """Return True when `html` is a JS app shell with no tank markup.
+
+    The tanks page now ships as scripts and an empty body. That is not an
+    empty account and it is not a login page; the tanks are on the JSON
+    API behind the same path.
+    """
+    if looks_like_json(html) or looks_like_login_page(html):
+        return False
+    soup = BeautifulSoup(html, "html.parser")
+    if looks_like_empty_tank_list(soup):
+        return False
+    shape = describe_page_shape(html)
+    return (
+        shape["is_html"]
+        and shape["scripts"] > 0
+        and shape["tank_links"] == 0
+        and shape["forms"] == 0
+    )
+
+
+def _load_json(body: str) -> Any:
+    """Parse `body` as JSON, or raise a parse error that names no content."""
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        raise BoilerJuiceParseError(
+            "The BoilerJuice response looked like JSON but did not parse"
+        ) from None
+
+
+def _json_type(value: Any) -> str:
+    """Return a JSON type name, never the value itself."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "list"
+    if isinstance(value, dict):
+        return "object"
+    return "other"
+
+
+def describe_json_shape(data: Any) -> dict[str, Any]:
+    """Describe a JSON payload without reproducing any of its values.
+
+    Safe to log and to paste into an issue: keys and types only.
+    """
+    if isinstance(data, list):
+        keys: set[str] = set()
+        for item in data:
+            if isinstance(item, dict):
+                keys.update(str(key) for key in item)
+        return {
+            "is_json": True,
+            "type": "list",
+            "length": len(data),
+            "item_keys": sorted(keys),
+        }
+    if isinstance(data, dict):
+        return {
+            "is_json": True,
+            "type": "object",
+            "keys": sorted(str(key) for key in data),
+            "nested": {str(key): _json_type(value) for key, value in data.items()},
+        }
+    return {"is_json": True, "type": _json_type(data)}
+
+
+def looks_like_json_sign_in(body: str) -> bool:
+    """Return True when a JSON body is Devise's "please sign in" error."""
+    if not looks_like_json(body):
+        return False
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        return False
+    return _json_says_sign_in(data)
+
+
+def _json_says_sign_in(data: Any) -> bool:
+    """Return True when `data` is the unauthenticated JSON error."""
+    if not isinstance(data, dict):
+        return False
+    error = data.get("error")
+    return isinstance(error, str) and "sign in" in error.lower()
+
+
+def _tank_objects(data: Any) -> list[dict[str, Any]] | None:
+    """Return the tank objects in `data`, or None if the shape is unknown.
+
+    An empty list means the payload is a recognised tank list with nothing
+    in it. None means we do not understand the payload, which is a parse
+    failure rather than an empty account.
+    """
+    if isinstance(data, list):
+        if all(isinstance(item, dict) for item in data):
+            return list(data)
+        return None
+    if not isinstance(data, dict):
+        return None
+    for key in _JSON_LIST_KEYS:
+        value = data.get(key)
+        if isinstance(value, list) and all(isinstance(item, dict) for item in value):
+            return list(value)
+    if any(key in data for key in _JSON_ID_KEYS):
+        return [data]
+    return None
+
+
+def _collect_dicts(obj: dict[str, Any], *, depth: int = 0) -> list[dict[str, Any]]:
+    """Return `obj` and its nested objects, two levels down.
+
+    Readings sometimes live on a child (`latest_reading`, `monitor`) rather
+    than on the tank itself. Deeper walking would start inventing values
+    from unrelated nested documents.
+    """
+    found = [obj]
+    if depth >= 2:
+        return found
+    for value in obj.values():
+        if isinstance(value, dict):
+            found.extend(_collect_dicts(value, depth=depth + 1))
+    return found
+
+
+def _first_converted(
+    objects: list[dict[str, Any]],
+    keys: tuple[str, ...],
+    convert: Callable[[Any], Any],
+) -> Any:
+    """Return the first value under `keys` that survives `convert`."""
+    for obj in objects:
+        for key in keys:
+            if key not in obj:
+                continue
+            converted = convert(obj[key])
+            if converted is not None:
+                return converted
+    return None
+
+
+def _first_raw(objects: list[dict[str, Any]], keys: tuple[str, ...]) -> Any:
+    """Return the first present value under `keys`, unconverted."""
+    for obj in objects:
+        for key in keys:
+            if key in obj:
+                return obj[key]
+    return None
+
+
+def _shape_from_json(value: Any) -> str | None:
+    """Return a known tank shape, formatted the way the HTML parser does."""
+    if not isinstance(value, str):
+        return None
+    key = value.strip().lower().replace(" ", "_")
+    if key not in _SHAPES:
+        return None
+    return key.replace("_", " ").title()
+
+
+def _oil_type_from_json(value: Any) -> str | None:
+    """Return an oil type name from a string or a small object."""
+    if isinstance(value, str):
+        return _text(value)
+    if isinstance(value, dict):
+        return _text(value.get("name") or value.get("label"))
+    return None
+
+
+def _model_id_from_json(value: Any) -> str | None:
+    """Return a model id as a string, or None if there is not one."""
+    if value is None or value == "":
+        return None
+    return _text(str(value))
+
+
+def _parse_tank_ids_json(body: str) -> list[str]:
+    """Return tank ids from a JSON listing, or raise."""
+    data = _load_json(body)
+    if _json_says_sign_in(data):
+        raise BoilerJuiceAuthError(
+            "BoilerJuice served the sign-in error; the session expired or the "
+            "credentials were rejected"
+        )
+    objects = _tank_objects(data)
+    if objects is None:
+        raise BoilerJuiceParseError(
+            "The BoilerJuice tanks JSON listed no tanks and was not an empty "
+            f"list; refusing to treat it as proof that the tanks are gone "
+            f"(page shape: {describe_json_shape(data)})"
+        )
+    tank_ids: list[str] = []
+    for obj in objects:
+        tank_id = validate_tank_id(_first_raw([obj], _JSON_ID_KEYS))
+        if tank_id is not None and tank_id not in tank_ids:
+            tank_ids.append(tank_id)
+    return tank_ids
+
+
+def _parse_tank_json(body: str, tank_id: str) -> TankReading:
+    """Parse a JSON tank document into a validated reading."""
+    canonical = validate_tank_id(tank_id)
+    if canonical is None:
+        raise BoilerJuiceParseError("Refusing to use a non-numeric tank id")
+
+    data = _load_json(body)
+    if _json_says_sign_in(data):
+        raise BoilerJuiceAuthError(
+            "BoilerJuice served the sign-in error; the session expired or the "
+            "credentials were rejected"
+        )
+    objects = _tank_objects(data)
+    if objects is None:
+        raise BoilerJuiceParseError(
+            "The BoilerJuice tank JSON was not a tank object "
+            f"(page shape: {describe_json_shape(data)})"
+        )
+    if len(objects) == 1:
+        chosen = objects[0]
+    else:
+        chosen = next(
+            (
+                obj
+                for obj in objects
+                if validate_tank_id(_first_raw([obj], _JSON_ID_KEYS)) == canonical
+            ),
+            None,
+        )
+        if chosen is None:
+            raise BoilerJuiceParseError(
+                "The BoilerJuice tank JSON listed tanks but not the one "
+                f"requested (page shape: {describe_json_shape(data)})"
+            )
+
+    fields = _collect_dicts(chosen)
+    reading = TankReading(
+        tank_id=canonical,
+        level_percentage=_first_converted(fields, _JSON_LEVEL_KEYS, percentage),
+        volume_litres=_first_converted(fields, _JSON_VOLUME_KEYS, volume_litres),
+        capacity_litres=_first_converted(fields, _JSON_CAPACITY_KEYS, capacity_litres),
+        height_cm=_first_converted(fields, _JSON_HEIGHT_KEYS, height_cm),
+        name=_first_converted(fields, _JSON_NAME_KEYS, _text),
+        model=_first_converted(fields, _JSON_MODEL_KEYS, _text),
+        model_id=_first_converted(fields, _JSON_MODEL_ID_KEYS, _model_id_from_json),
+        manufacturer=_first_converted(fields, _JSON_MANUFACTURER_KEYS, _text),
+        shape=_first_converted(fields, _JSON_SHAPE_KEYS, _shape_from_json),
+        oil_type=_first_converted(fields, _JSON_OIL_TYPE_KEYS, _oil_type_from_json),
+    )
+    if not reading.has_measurement:
+        raise BoilerJuiceParseError(
+            "The BoilerJuice tank JSON contained neither an oil level nor an "
+            f"oil volume; refusing to treat it as a reading "
+            f"(page shape: {describe_json_shape(data)})"
+        )
+    return reading
 
 
 def _first_input_value(
@@ -372,7 +686,9 @@ def _parse_shape(soup: BeautifulSoup) -> str | None:
 
 def _parse_oil_type(soup: BeautifulSoup) -> str | None:
     """Return the selected oil type."""
-    select = soup.find("select", {"id": "tank_oil_type_id"})
+    select = soup.find("select", {"id": "tank_oil_type_id"}) or soup.find(
+        "select", {"id": "oil_type_id"}
+    )
     if select is None:
         return None
     selected = select.find("option", selected=True)
@@ -464,6 +780,8 @@ def parse_tank_page(html: str, tank_id: str) -> TankReading:
             "BoilerJuice served the sign-in page; the session expired or the "
             "credentials were rejected"
         )
+    if looks_like_json(html):
+        return _parse_tank_json(html, tank_id)
 
     canonical_tank_id = validate_tank_id(tank_id)
     if canonical_tank_id is None:
@@ -484,7 +802,9 @@ def parse_tank_page(html: str, tank_id: str) -> TankReading:
             soup, ("internal_height", "tank-height-count"), height_cm
         ),
         name=_attribute(
-            soup.find("input", {"id": "tank_user_tanks_attributes_0_name"}), "value"
+            soup.find("input", {"id": "tank_user_tanks_attributes_0_name"})
+            or soup.find("input", {"id": "name", "name": "name"}),
+            "value",
         ),
         model=model,
         model_id=model_id,

--- a/custom_components/boilerjuice/parser.py
+++ b/custom_components/boilerjuice/parser.py
@@ -374,7 +374,7 @@ def looks_like_javascript_shell(html: str) -> bool:
     if looks_like_empty_tank_list(soup):
         return False
     shape = describe_page_shape(html)
-    return (
+    return bool(
         shape["is_html"]
         and shape["scripts"] > 0
         and shape["tank_links"] == 0
@@ -385,7 +385,7 @@ def looks_like_javascript_shell(html: str) -> bool:
 def _load_json(body: str) -> Any:
     """Parse `body` as JSON, or raise a parse error that names no content."""
     try:
-        return json.loads(body)
+        return json.loads(body.lstrip("\ufeff \t\r\n"))
     except json.JSONDecodeError:
         raise BoilerJuiceParseError(
             "The BoilerJuice response looked like JSON but did not parse"
@@ -587,19 +587,17 @@ def _parse_tank_json(body: str, tank_id: str) -> TankReading:
     if len(objects) == 1:
         chosen = objects[0]
     else:
-        chosen = next(
-            (
-                obj
-                for obj in objects
-                if validate_tank_id(_first_raw([obj], _JSON_ID_KEYS)) == canonical
-            ),
-            None,
-        )
-        if chosen is None:
+        matches = [
+            obj
+            for obj in objects
+            if validate_tank_id(_first_raw([obj], _JSON_ID_KEYS)) == canonical
+        ]
+        if not matches:
             raise BoilerJuiceParseError(
                 "The BoilerJuice tank JSON listed tanks but not the one "
                 f"requested (page shape: {describe_json_shape(data)})"
             )
+        chosen = matches[0]
 
     fields = _collect_dicts(chosen)
     reading = TankReading(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -80,10 +80,10 @@ async def test_a_lapsed_session_is_renewed_once_and_the_fetch_retried(
     bodies = iter([load_fixture("login.html"), tank_page(percentage=80, litres=2000)])
     fetch = client._async_get
 
-    async def bounce_once(url: str, description: str):
+    async def bounce_once(url: str, description: str, **kwargs):
         if url == TANK_URL:
             return next(bodies), url
-        return await fetch(url, description)
+        return await fetch(url, description, **kwargs)
 
     client._async_get = bounce_once
 
@@ -125,6 +125,40 @@ async def test_http_statuses_map_onto_distinct_errors(
 
     with pytest.raises(expected):
         await client.async_fetch_tank("123456")
+
+
+async def test_a_chunked_body_is_read_in_full() -> None:
+    """content.read(n) on the live site returned only the HTML head.
+
+    That truncated page had scripts and no tank links, so we reported a
+    JavaScript rewrite. response.read() waits for the decoded payload.
+    """
+
+    class FakeStream:
+        def __init__(self, partial: bytes) -> None:
+            self.partial = partial
+
+        async def read(self, _n: int = -1) -> bytes:
+            return self.partial
+
+    class FakeResponse:
+        charset = "utf-8"
+
+        def __init__(self) -> None:
+            self._full = (
+                b"<!DOCTYPE html><html><head>"
+                b'<script src="/app.js"></script></head>'
+                b'<body><a href="/uk/users/tanks/123456">Tank</a></body></html>'
+            )
+            self.content = FakeStream(self._full.split(b"</head>")[0])
+
+        async def read(self) -> bytes:
+            return self._full
+
+    text = await BoilerJuiceClient._read_text(FakeResponse(), "tank page")
+
+    assert "tanks/123456" in text
+    assert text.count("<script") == 1
 
 
 async def test_an_oversized_response_is_refused(
@@ -473,3 +507,88 @@ async def test_a_transport_error_does_not_carry_the_tank_id(
     assert isinstance(cause, RedactedTransportError)
     assert "ClientResponseError" in str(cause)
     assert "123456" not in str(cause)
+
+
+# --- the JavaScript app returns JSON --------------------------------------
+
+
+async def test_a_javascript_shell_falls_back_to_the_json_url(
+    aioclient_mock: AiohttpClientMocker, client: BoilerJuiceClient
+) -> None:
+    """Accept: application/json is ignored; the HTML is an empty JS app."""
+    mock_sign_in(aioclient_mock)
+    aioclient_mock.get(
+        TANKS_URL,
+        text=(
+            "<!DOCTYPE html><html><head>"
+            '<script src="/assets/application.js"></script>'
+            "</head><body><div id='app'></div></body></html>"
+        ),
+    )
+    aioclient_mock.get(
+        f"{TANKS_URL}.json",
+        text='[{"id": 123456, "name": "Garden"}]',
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert await client.async_list_tank_ids() == ["123456"]
+
+
+async def test_listing_tanks_reads_json(
+    aioclient_mock: AiohttpClientMocker, client: BoilerJuiceClient
+) -> None:
+    mock_sign_in(aioclient_mock)
+    aioclient_mock.get(
+        TANKS_URL,
+        text='[{"id": 123456, "name": "Garden"}, {"id": 789012, "name": "Barn"}]',
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert await client.async_list_tank_ids() == ["123456", "789012"]
+
+
+async def test_fetching_a_tank_reads_json(
+    aioclient_mock: AiohttpClientMocker, client: BoilerJuiceClient
+) -> None:
+    mock_sign_in(aioclient_mock)
+    aioclient_mock.get(
+        TANK_URL,
+        text='{"id": 123456, "percentage": 80, "litres": 2000}',
+        headers={"Content-Type": "application/json"},
+    )
+
+    reading = await client.async_fetch_tank("123456")
+
+    assert reading.volume_litres == 2000
+    assert reading.level_percentage == 80
+
+
+async def test_a_json_401_is_renewed_once_and_the_fetch_retried(
+    aioclient_mock: AiohttpClientMocker, client: BoilerJuiceClient
+) -> None:
+    """The JSON API answers a lapsed session with 401, not the login page."""
+    mock_sign_in(aioclient_mock)
+
+    outcomes = iter(
+        [
+            BoilerJuiceAuthError("BoilerJuice refused access to the tank page"),
+            ('{"id": 123456, "percentage": 80, "litres": 2000}', TANK_URL),
+        ]
+    )
+    fetch = client._async_get
+
+    async def bounce_once(url: str, description: str, **kwargs):
+        if url == TANK_URL:
+            item = next(outcomes)
+            if isinstance(item, Exception):
+                raise item
+            return item
+        return await fetch(url, description, **kwargs)
+
+    client._async_get = bounce_once
+
+    reading = await client.async_fetch_tank("123456")
+
+    assert reading.volume_litres == 2000
+    logins = [call for call in aioclient_mock.mock_calls if call[0] == "POST"]
+    assert len(logins) == 2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -77,7 +77,7 @@ def test_parses_the_renamed_name_and_oil_type_fields() -> None:
         '<div id="usable-oil"><div class="oil-level" data-percentage="50"></div></div>'
         '<input id="name" name="name" value="Garden Tank">'
         '<select id="oil_type_id"><option>Gas Oil</option>'
-        '<option selected>Kerosene</option></select>'
+        "<option selected>Kerosene</option></select>"
     )
     reading = parse_tank_page(html, "123456")
 
@@ -632,9 +632,7 @@ def test_json_listing_an_object_without_tanks_is_a_parse_error() -> None:
 
 def test_json_sign_in_error_is_an_auth_error() -> None:
     with pytest.raises(BoilerJuiceAuthError):
-        parse_tank_ids(
-            '{"error":"You need to sign in or sign up before continuing."}'
-        )
+        parse_tank_ids('{"error":"You need to sign in or sign up before continuing."}')
 
 
 def test_json_tank_parses_a_flat_object() -> None:
@@ -740,3 +738,98 @@ def test_looks_like_json_sign_in() -> None:
     )
     assert parser.looks_like_json_sign_in("<html></html>") is False
     assert parser.looks_like_json_sign_in("{not-json") is False
+    assert parser.looks_like_json_sign_in("[1, 2]") is False
+
+
+def test_describe_json_shape_of_a_list_and_a_scalar() -> None:
+    assert parser.describe_json_shape([{"id": 1}, "skip", {"name": "x"}]) == {
+        "is_json": True,
+        "type": "list",
+        "length": 3,
+        "item_keys": ["id", "name"],
+    }
+    assert parser.describe_json_shape(7) == {"is_json": True, "type": "number"}
+    assert parser.describe_json_shape(None) == {"is_json": True, "type": "null"}
+    assert parser.describe_json_shape(True) == {"is_json": True, "type": "boolean"}
+
+
+def test_json_tank_sign_in_error_is_an_auth_error() -> None:
+    with pytest.raises(BoilerJuiceAuthError):
+        parse_tank_page(
+            '{"error":"You need to sign in or sign up before continuing."}',
+            "123456",
+        )
+
+
+def test_json_tank_refuses_a_non_numeric_id() -> None:
+    with pytest.raises(BoilerJuiceParseError):
+        parse_tank_page('{"id": 1, "percentage": 50}', "../admin")
+
+
+def test_json_tank_unrecognised_payload_raises() -> None:
+    with pytest.raises(BoilerJuiceParseError) as caught:
+        parse_tank_page("[1, 2, 3]", "123456")
+
+    assert "page shape" in str(caught.value)
+
+
+def test_json_tank_list_without_the_requested_id_raises() -> None:
+    with pytest.raises(BoilerJuiceParseError):
+        parse_tank_page(
+            '[{"id": 111, "percentage": 10}, {"id": 222, "percentage": 20}]',
+            "123456",
+        )
+
+
+def test_json_tank_reads_oil_type_object_and_numeric_model_id() -> None:
+    reading = parse_tank_page(
+        json.dumps(
+            {
+                "id": 123456,
+                "percentage": 50,
+                "oil_type": {"name": "Kerosene"},
+                "model_id": 42,
+                "shape": "not-a-shape",
+            }
+        ),
+        "123456",
+    )
+
+    assert reading.oil_type == "Kerosene"
+    assert reading.model_id == "42"
+    assert reading.shape is None
+
+
+def test_json_listing_skips_objects_without_an_id() -> None:
+    assert parse_tank_ids('[{"name": "orphan"}, {"id": 123456}]') == ["123456"]
+
+
+def test_json_listing_accepts_a_user_tanks_wrapper() -> None:
+    assert parse_tank_ids('{"user_tanks": [{"id": 7}]}') == ["7"]
+
+
+def test_json_with_a_bom_still_parses() -> None:
+    assert parse_tank_ids('\ufeff{"tanks": []}') == []
+
+
+def test_an_empty_account_page_is_not_a_javascript_shell() -> None:
+    assert (
+        parser.looks_like_javascript_shell(load_fixture("tanks_list_empty.html"))
+        is False
+    )
+    assert parser.looks_like_javascript_shell('[{"id": 1}]') is False
+
+
+def test_json_reads_a_reading_two_objects_down() -> None:
+    reading = parse_tank_page(
+        json.dumps(
+            {
+                "id": 123456,
+                "monitor": {"latest_reading": {"percentage": 33, "litres": 800}},
+            }
+        ),
+        "123456",
+    )
+
+    assert reading.level_percentage == 33
+    assert reading.volume_litres == 800

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -71,6 +71,20 @@ def test_login_page_raises_auth_rather_than_parse_error() -> None:
         parse_tank_page(load_fixture("login.html"), "123456")
 
 
+def test_parses_the_renamed_name_and_oil_type_fields() -> None:
+    """The edit page now uses id=name and id=oil_type_id."""
+    html = (
+        '<div id="usable-oil"><div class="oil-level" data-percentage="50"></div></div>'
+        '<input id="name" name="name" value="Garden Tank">'
+        '<select id="oil_type_id"><option>Gas Oil</option>'
+        '<option selected>Kerosene</option></select>'
+    )
+    reading = parse_tank_page(html, "123456")
+
+    assert reading.name == "Garden Tank"
+    assert reading.oil_type == "Kerosene"
+
+
 def test_partial_page_keeps_the_level_and_omits_the_volume() -> None:
     """A level with no volume is a usable reading; the volume must stay absent.
 
@@ -560,3 +574,169 @@ def test_an_unreadable_tanks_page_reports_its_shape() -> None:
         parse_tank_ids(CHALLENGE)
 
     assert "cloudflare" in str(caught.value)
+
+
+# --- the JavaScript app's JSON API ----------------------------------------
+
+JS_SHELL = """
+<!DOCTYPE html>
+<html><head><title>Your tanks</title>
+<script src="/assets/application.js"></script>
+<script src="/assets/tanks.js"></script>
+</head><body><div id="app"></div></body></html>
+"""
+
+
+def test_a_javascript_shell_is_recognised() -> None:
+    assert parser.looks_like_javascript_shell(JS_SHELL)
+    assert parser.looks_like_javascript_shell(load_fixture("tanks_list.html")) is False
+    assert parser.looks_like_javascript_shell(load_fixture("login.html")) is False
+
+
+def test_a_javascript_shell_is_not_an_empty_account() -> None:
+    """The tanks page is now a JS app: 15 scripts, no links, no forms.
+
+    Treating that as "no tanks" would retire every device on the account.
+    """
+    with pytest.raises(BoilerJuiceParseError) as caught:
+        parse_tank_ids(JS_SHELL)
+
+    assert "page shape" in str(caught.value)
+    assert "tank_links" in str(caught.value)
+
+
+def test_json_listing_returns_ids_in_order() -> None:
+    body = json.dumps(
+        [
+            {"id": 123456, "name": "Garden"},
+            {"id": 789012, "name": "Barn"},
+            {"id": 123456, "name": "Garden again"},
+        ]
+    )
+
+    assert parse_tank_ids(body) == ["123456", "789012"]
+
+
+def test_json_listing_accepts_a_wrapped_empty_list() -> None:
+    assert parse_tank_ids('{"tanks": []}') == []
+
+
+def test_json_listing_an_object_without_tanks_is_a_parse_error() -> None:
+    with pytest.raises(BoilerJuiceParseError) as caught:
+        parse_tank_ids('{"status": "ok", "count": 2}')
+
+    assert "page shape" in str(caught.value)
+    assert "status" in str(caught.value)
+    assert "ok" not in str(caught.value)
+
+
+def test_json_sign_in_error_is_an_auth_error() -> None:
+    with pytest.raises(BoilerJuiceAuthError):
+        parse_tank_ids(
+            '{"error":"You need to sign in or sign up before continuing."}'
+        )
+
+
+def test_json_tank_parses_a_flat_object() -> None:
+    body = json.dumps(
+        {
+            "id": 123456,
+            "name": "Garden Tank",
+            "percentage": 62.5,
+            "litres": 1562,
+            "tank_size": 2500,
+            "internal_height": 120,
+            "shape": "horizontal_cylinder",
+            "oil_type": "Kerosene",
+            "model": "H2500T",
+            "manufacturer": "Harlequin",
+        }
+    )
+    reading = parse_tank_page(body, "123456")
+
+    assert reading.tank_id == "123456"
+    assert reading.level_percentage == 62.5
+    assert reading.volume_litres == 1562
+    assert reading.capacity_litres == 2500
+    assert reading.height_cm == 120
+    assert reading.name == "Garden Tank"
+    assert reading.shape == "Horizontal Cylinder"
+    assert reading.oil_type == "Kerosene"
+    assert reading.model == "H2500T"
+    assert reading.manufacturer == "Harlequin"
+
+
+def test_json_tank_reads_a_nested_latest_reading() -> None:
+    body = json.dumps(
+        {
+            "id": 123456,
+            "name": "Garden Tank",
+            "latest_reading": {"percentage": 40, "litres": 1000},
+        }
+    )
+    reading = parse_tank_page(body, "123456")
+
+    assert reading.level_percentage == 40
+    assert reading.volume_litres == 1000
+    assert reading.name == "Garden Tank"
+
+
+def test_json_tank_picks_the_requested_id_from_a_list() -> None:
+    body = json.dumps(
+        [
+            {"id": 111, "percentage": 10, "litres": 100},
+            {"id": 123456, "percentage": 80, "litres": 2000},
+        ]
+    )
+    reading = parse_tank_page(body, "123456")
+
+    assert reading.level_percentage == 80
+    assert reading.volume_litres == 2000
+
+
+def test_json_tank_without_a_measurement_raises() -> None:
+    with pytest.raises(BoilerJuiceParseError) as caught:
+        parse_tank_page('{"id": 123456, "name": "Garden Tank"}', "123456")
+
+    assert "neither an oil level nor an oil volume" in str(caught.value)
+    assert "Garden Tank" not in str(caught.value)
+
+
+def test_json_shape_carries_no_values() -> None:
+    data = {
+        "name": "Wilhelmina Bracegirdle",
+        "email": "will@together.agency",
+        "tanks": [{"id": 998877, "address": "12 Sycamore Lane"}],
+    }
+    serialised = json.dumps(parser.describe_json_shape(data))
+
+    for secret in (
+        "Wilhelmina",
+        "Bracegirdle",
+        "will@together.agency",
+        "998877",
+        "Sycamore",
+    ):
+        assert secret not in serialised, f"the JSON shape leaked {secret!r}"
+
+    assert parser.describe_json_shape(data) == {
+        "is_json": True,
+        "type": "object",
+        "keys": ["email", "name", "tanks"],
+        "nested": {"email": "string", "name": "string", "tanks": "list"},
+    }
+
+
+def test_broken_json_raises_without_quoting_the_body() -> None:
+    with pytest.raises(BoilerJuiceParseError) as caught:
+        parse_tank_ids('{"name": "Wilhelmina",')
+
+    assert "Wilhelmina" not in str(caught.value)
+
+
+def test_looks_like_json_sign_in() -> None:
+    assert parser.looks_like_json_sign_in(
+        '{"error":"You need to sign in or sign up before continuing."}'
+    )
+    assert parser.looks_like_json_sign_in("<html></html>") is False
+    assert parser.looks_like_json_sign_in("{not-json") is False


### PR DESCRIPTION
## Summary
- A live poll that looked like a JavaScript rewrite was a truncated HTML body: `content.read(n)` on a chunked, gzipped response returned only the `<head>` (scripts, no forms, no tank links).
- The client now uses `response.read()`, then enforces the size cap, so the real tanks and edit pages parse again.
- HTML is still the primary path (`Accept: application/json` on those URLs is a 500 when signed in). JSON listing/detail is a fallback if a real JS shell arrives, and the parser accepts the renamed `name` / `oil_type_id` fields.

## Test plan
- [x] Live sign-in, list tanks, fetch tank, fetch price — every reading field present
- [ ] CI: ruff, mypy, both Home Assistant test lanes
- [ ] After merge, cut a beta and confirm Home Assistant updates without the parse error