### PR TITLE
Refuse an unreadable JSON tank list as an empty account

### DIFF
--- a/custom_components/boilerjuice/client.py
+++ b/custom_components/boilerjuice/client.py
@@ -51,6 +51,7 @@ REQUEST_TIMEOUT = aiohttp.ClientTimeout(
 # A tank page is a few hundred kilobytes. Anything vastly larger is not a
 # page we can use, and reading it would just burn memory.
 MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+READ_CHUNK_BYTES = 64 * 1024
 
 SessionFactory = Callable[[aiohttp.ClientTimeout], aiohttp.ClientSession]
 
@@ -146,20 +147,30 @@ class BoilerJuiceClient:
 
     @staticmethod
     async def _read_text(response: aiohttp.ClientResponse, description: str) -> str:
-        """Read a bounded amount of body text from `response`.
+        """Read a bounded amount of decoded body text from `response`.
 
-        Must use ``response.read()``, not ``response.content.read(n)``.
-        On the live site the body is chunked and gzipped; a sized stream
-        read returned only the ``<head>`` — scripts, no forms, no tank
-        links — which we then described as a JavaScript app rewrite.
-        ``read()`` waits for the decoded payload, then we enforce the cap.
+        The body is consumed in chunks from the decoded stream. A single
+        ``content.read(n)`` on the live site returned only the HTML
+        ``<head>`` — the first chunk of a chunked, gzipped payload —
+        which we then described as a JavaScript app rewrite. Looping
+        until the stream ends collects the full page. Stopping as soon
+        as the accumulated size exceeds the cap means a runaway
+        response is never fully materialised.
         """
-        raw = await response.read()
-        if len(raw) > MAX_RESPONSE_BYTES:
-            raise BoilerJuiceParseError(
-                f"The {description} was larger than {MAX_RESPONSE_BYTES} bytes"
-            )
-        return raw.decode(response.charset or "utf-8", errors="replace")
+        chunks: list[bytes] = []
+        total = 0
+        reader = response.content
+        while True:
+            chunk = await reader.read(READ_CHUNK_BYTES)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > MAX_RESPONSE_BYTES:
+                raise BoilerJuiceParseError(
+                    f"The {description} was larger than {MAX_RESPONSE_BYTES} bytes"
+                )
+            chunks.append(chunk)
+        return b"".join(chunks).decode(response.charset or "utf-8", errors="replace")
 
     async def _async_get(
         self,

--- a/custom_components/boilerjuice/parser.py
+++ b/custom_components/boilerjuice/parser.py
@@ -560,6 +560,11 @@ def _first_raw(objects: list[dict[str, Any]], keys: tuple[str, ...]) -> Any:
     return None
 
 
+def _has_tank_id_key(obj: dict[str, Any]) -> bool:
+    """Return True when a tank-id field is present, even if unreadable."""
+    return any(key in obj for key in _JSON_ID_KEYS)
+
+
 def _shape_from_json(value: Any) -> str | None:
     """Return a known tank shape, formatted the way the HTML parser does."""
     if not isinstance(value, str):
@@ -602,17 +607,22 @@ def _parse_tank_ids_json(body: str) -> list[str]:
             f"(page shape: {describe_json_shape(data)})"
         )
     tank_ids: list[str] = []
+    unreadable = False
     for obj in objects:
         tank_id = validate_tank_id(_first_raw([obj], _JSON_ID_KEYS))
-        if tank_id is not None and tank_id not in tank_ids:
+        if tank_id is None:
+            # Track this apart from deduplication. A sibling we cannot
+            # name is not "absent"; treating the rest as complete would
+            # retire that tank after three polls.
+            unreadable = True
+            continue
+        if tank_id not in tank_ids:
             tank_ids.append(tank_id)
-    if objects and not tank_ids:
-        # A non-empty list of objects we cannot identify is unreadable,
-        # not empty. Returning [] here would retire every tank device.
+    if unreadable:
         raise BoilerJuiceParseError(
-            "The BoilerJuice tanks JSON listed objects but none had a "
-            "readable tank id; refusing to treat it as proof that the "
-            f"tanks are gone (page shape: {describe_json_shape(data)})"
+            "The BoilerJuice tanks JSON listed objects that could not all "
+            "be identified; refusing to treat the listing as complete "
+            f"(page shape: {describe_json_shape(data)})"
         )
     return tank_ids
 
@@ -642,11 +652,9 @@ def _parse_tank_json(body: str, tank_id: str) -> TankReading:
     ]
     if matches:
         chosen = matches[0]
-    elif len(objects) == 1 and (
-        validate_tank_id(_first_raw([objects[0]], _JSON_ID_KEYS)) is None
-    ):
-        # A singleton document with no readable id is the page we asked
-        # for. A readable id that names a different tank is not.
+    elif len(objects) == 1 and not _has_tank_id_key(objects[0]):
+        # A singleton with no id field is the document we asked for.
+        # An explicit id that is invalid or names another tank is not.
         chosen = objects[0]
     else:
         raise BoilerJuiceParseError(

--- a/custom_components/boilerjuice/parser.py
+++ b/custom_components/boilerjuice/parser.py
@@ -354,10 +354,37 @@ _JSON_MANUFACTURER_KEYS = ("manufacturer", "Brand", "brand")
 _JSON_MODEL_ID_KEYS = ("model_id", "tank_model_id")
 _JSON_LIST_KEYS = ("tanks", "user_tanks", "data", "results")
 
+# Field names we already understand. The shape reporter may name these
+# and nothing else: an unexpected payload can use a tank id or an email
+# address as a key, and those must not reach a log or a diagnostic.
+_RECOGNISED_JSON_KEYS = frozenset(
+    (
+        *_JSON_ID_KEYS,
+        *_JSON_LEVEL_KEYS,
+        *_JSON_VOLUME_KEYS,
+        *_JSON_CAPACITY_KEYS,
+        *_JSON_HEIGHT_KEYS,
+        *_JSON_NAME_KEYS,
+        *_JSON_SHAPE_KEYS,
+        *_JSON_OIL_TYPE_KEYS,
+        *_JSON_MODEL_KEYS,
+        *_JSON_MANUFACTURER_KEYS,
+        *_JSON_MODEL_ID_KEYS,
+        *_JSON_LIST_KEYS,
+        "error",
+    )
+)
+_MAX_SHAPE_KEYS = 32
+
+
+def _strip_json_prefix(body: str) -> str:
+    """Remove a UTF-8 BOM and leading whitespace so JSON parsers agree."""
+    return body.lstrip("\ufeff \t\r\n")
+
 
 def looks_like_json(body: str) -> bool:
     """Return True when `body` is more likely JSON than HTML."""
-    stripped = body.lstrip("\ufeff \t\r\n")
+    stripped = _strip_json_prefix(body)
     return stripped.startswith("{") or stripped.startswith("[")
 
 
@@ -385,7 +412,7 @@ def looks_like_javascript_shell(html: str) -> bool:
 def _load_json(body: str) -> Any:
     """Parse `body` as JSON, or raise a parse error that names no content."""
     try:
-        return json.loads(body.lstrip("\ufeff \t\r\n"))
+        return json.loads(_strip_json_prefix(body))
     except json.JSONDecodeError:
         raise BoilerJuiceParseError(
             "The BoilerJuice response looked like JSON but did not parse"
@@ -409,10 +436,18 @@ def _json_type(value: Any) -> str:
     return "other"
 
 
-def describe_json_shape(data: Any) -> dict[str, Any]:
-    """Describe a JSON payload without reproducing any of its values.
+def _recognised_key_names(keys: Any) -> list[str]:
+    """Return the allowlisted names in `keys`, sorted and capped."""
+    names = sorted({str(key) for key in keys if str(key) in _RECOGNISED_JSON_KEYS})
+    return names[:_MAX_SHAPE_KEYS]
 
-    Safe to log and to paste into an issue: keys and types only.
+
+def describe_json_shape(data: Any) -> dict[str, Any]:
+    """Describe a JSON payload without reproducing any of its content.
+
+    Safe to log and to paste into an issue: counts, JSON types, and a
+    capped allowlist of field names we already recognise. Arbitrary
+    keys are not copied; they can be tank ids or email addresses.
     """
     if isinstance(data, list):
         keys: set[str] = set()
@@ -423,14 +458,22 @@ def describe_json_shape(data: Any) -> dict[str, Any]:
             "is_json": True,
             "type": "list",
             "length": len(data),
-            "item_keys": sorted(keys),
+            "item_key_count": len(keys),
+            "recognised_item_keys": _recognised_key_names(keys),
         }
     if isinstance(data, dict):
+        recognised = _recognised_key_names(data)
+        nested: dict[str, str] = {}
+        for key, value in data.items():
+            name = str(key)
+            if name in recognised:
+                nested[name] = _json_type(value)
         return {
             "is_json": True,
             "type": "object",
-            "keys": sorted(str(key) for key in data),
-            "nested": {str(key): _json_type(value) for key, value in data.items()},
+            "key_count": len(data),
+            "recognised_keys": recognised,
+            "nested": nested,
         }
     return {"is_json": True, "type": _json_type(data)}
 
@@ -440,7 +483,7 @@ def looks_like_json_sign_in(body: str) -> bool:
     if not looks_like_json(body):
         return False
     try:
-        data = json.loads(body)
+        data = json.loads(_strip_json_prefix(body))
     except json.JSONDecodeError:
         return False
     return _json_says_sign_in(data)
@@ -563,6 +606,14 @@ def _parse_tank_ids_json(body: str) -> list[str]:
         tank_id = validate_tank_id(_first_raw([obj], _JSON_ID_KEYS))
         if tank_id is not None and tank_id not in tank_ids:
             tank_ids.append(tank_id)
+    if objects and not tank_ids:
+        # A non-empty list of objects we cannot identify is unreadable,
+        # not empty. Returning [] here would retire every tank device.
+        raise BoilerJuiceParseError(
+            "The BoilerJuice tanks JSON listed objects but none had a "
+            "readable tank id; refusing to treat it as proof that the "
+            f"tanks are gone (page shape: {describe_json_shape(data)})"
+        )
     return tank_ids
 
 
@@ -584,20 +635,24 @@ def _parse_tank_json(body: str, tank_id: str) -> TankReading:
             "The BoilerJuice tank JSON was not a tank object "
             f"(page shape: {describe_json_shape(data)})"
         )
-    if len(objects) == 1:
+    matches = [
+        obj
+        for obj in objects
+        if validate_tank_id(_first_raw([obj], _JSON_ID_KEYS)) == canonical
+    ]
+    if matches:
+        chosen = matches[0]
+    elif len(objects) == 1 and (
+        validate_tank_id(_first_raw([objects[0]], _JSON_ID_KEYS)) is None
+    ):
+        # A singleton document with no readable id is the page we asked
+        # for. A readable id that names a different tank is not.
         chosen = objects[0]
     else:
-        matches = [
-            obj
-            for obj in objects
-            if validate_tank_id(_first_raw([obj], _JSON_ID_KEYS)) == canonical
-        ]
-        if not matches:
-            raise BoilerJuiceParseError(
-                "The BoilerJuice tank JSON listed tanks but not the one "
-                f"requested (page shape: {describe_json_shape(data)})"
-            )
-        chosen = matches[0]
+        raise BoilerJuiceParseError(
+            "The BoilerJuice tank JSON listed tanks but not the one "
+            f"requested (page shape: {describe_json_shape(data)})"
+        )
 
     fields = _collect_dicts(chosen)
     reading = TankReading(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -128,37 +128,61 @@ async def test_http_statuses_map_onto_distinct_errors(
 
 
 async def test_a_chunked_body_is_read_in_full() -> None:
-    """content.read(n) on the live site returned only the HTML head.
+    """A single content.read(n) on the live site returned only the head.
 
-    That truncated page had scripts and no tank links, so we reported a
-    JavaScript rewrite. response.read() waits for the decoded payload.
+    The first decoded chunk of a chunked, gzipped page is the HTML
+    ``<head>``. Reading until the stream ends collects the tanks.
     """
+    head = b'<!DOCTYPE html><html><head><script src="/app.js"></script></head>'
+    rest = b'<body><a href="/uk/users/tanks/123456">Tank</a></body></html>'
 
     class FakeStream:
-        def __init__(self, partial: bytes) -> None:
-            self.partial = partial
+        def __init__(self) -> None:
+            self._chunks = [head, rest]
 
         async def read(self, _n: int = -1) -> bytes:
-            return self.partial
+            if not self._chunks:
+                return b""
+            return self._chunks.pop(0)
 
     class FakeResponse:
         charset = "utf-8"
 
         def __init__(self) -> None:
-            self._full = (
-                b"<!DOCTYPE html><html><head>"
-                b'<script src="/app.js"></script></head>'
-                b'<body><a href="/uk/users/tanks/123456">Tank</a></body></html>'
-            )
-            self.content = FakeStream(self._full.split(b"</head>")[0])
-
-        async def read(self) -> bytes:
-            return self._full
+            self.content = FakeStream()
 
     text = await BoilerJuiceClient._read_text(FakeResponse(), "tank page")
 
     assert "tanks/123456" in text
     assert text.count("<script") == 1
+
+
+async def test_an_oversized_response_stops_being_read() -> None:
+    """The size cap is enforced while reading, not after the body arrives."""
+    chunk = b"x" * (512 * 1024)
+
+    class CountingStream:
+        def __init__(self) -> None:
+            self.reads = 0
+
+        async def read(self, _n: int = -1) -> bytes:
+            self.reads += 1
+            return chunk
+
+    class FakeResponse:
+        charset = "utf-8"
+
+        def __init__(self) -> None:
+            self.content = CountingStream()
+
+    response = FakeResponse()
+    with pytest.raises(BoilerJuiceParseError):
+        await BoilerJuiceClient._read_text(response, "tank page")
+
+    # Eight 512 KiB chunks are exactly the limit and are kept. The ninth
+    # exceeds it, so we stop without asking for a tenth.
+    assert response.content.reads == 9
+    assert MAX_RESPONSE_BYTES // len(chunk) == 8
 
 
 async def test_an_oversized_response_is_refused(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -637,11 +637,22 @@ def test_json_listing_of_objects_without_ids_is_not_an_empty_account() -> None:
     with pytest.raises(BoilerJuiceParseError) as caught:
         parse_tank_ids('[{"name": "Garden"}]')
 
-    assert "readable tank id" in str(caught.value)
+    assert "could not all be identified" in str(caught.value)
     assert "Garden" not in str(caught.value)
     with pytest.raises(BoilerJuiceParseError):
         parse_tank_ids('{"tanks": [{"name": "Garden"}]}')
     assert parse_tank_ids("[]") == []
+
+
+def test_json_listing_of_a_partially_identified_list_is_not_authoritative() -> None:
+    """One readable id does not make the unreadables authoritatively gone."""
+    with pytest.raises(BoilerJuiceParseError) as caught:
+        parse_tank_ids('[{"id": 123456}, {"name": "unidentified tank"}]')
+
+    message = str(caught.value)
+    assert "could not all be identified" in message
+    assert "123456" not in message
+    assert "unidentified" not in message
 
 
 def test_json_sign_in_error_is_an_auth_error() -> None:
@@ -719,6 +730,21 @@ def test_json_tank_singleton_without_an_id_is_the_requested_tank() -> None:
 
     assert reading.tank_id == "123456"
     assert reading.level_percentage == 50
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        '{"id": "not-a-tank", "percentage": 50}',
+        '{"id": null, "percentage": 50}',
+        '{"id": "", "percentage": 50}',
+    ],
+)
+def test_json_tank_singleton_with_an_unreadable_id_raises(body: str) -> None:
+    with pytest.raises(BoilerJuiceParseError) as caught:
+        parse_tank_page(body, "123456")
+
+    assert "not-a-tank" not in str(caught.value)
 
 
 def test_json_tank_without_a_measurement_raises() -> None:
@@ -857,8 +883,12 @@ def test_json_tank_reads_oil_type_object_and_numeric_model_id() -> None:
     assert reading.shape is None
 
 
-def test_json_listing_skips_objects_without_an_id() -> None:
-    assert parse_tank_ids('[{"name": "orphan"}, {"id": 123456}]') == ["123456"]
+def test_json_listing_of_an_object_with_an_invalid_id_is_not_authoritative() -> None:
+    with pytest.raises(BoilerJuiceParseError) as caught:
+        parse_tank_ids('[{"id": 123456}, {"id": "not-a-tank"}]')
+
+    assert "123456" not in str(caught.value)
+    assert "not-a-tank" not in str(caught.value)
 
 
 def test_json_listing_accepts_a_user_tanks_wrapper() -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -625,9 +625,23 @@ def test_json_listing_an_object_without_tanks_is_a_parse_error() -> None:
     with pytest.raises(BoilerJuiceParseError) as caught:
         parse_tank_ids('{"status": "ok", "count": 2}')
 
-    assert "page shape" in str(caught.value)
-    assert "status" in str(caught.value)
-    assert "ok" not in str(caught.value)
+    message = str(caught.value)
+    assert "page shape" in message
+    assert "key_count" in message
+    assert "ok" not in message
+    assert "status" not in message
+
+
+def test_json_listing_of_objects_without_ids_is_not_an_empty_account() -> None:
+    """A list we cannot identify is unreadable, not proof the tanks are gone."""
+    with pytest.raises(BoilerJuiceParseError) as caught:
+        parse_tank_ids('[{"name": "Garden"}]')
+
+    assert "readable tank id" in str(caught.value)
+    assert "Garden" not in str(caught.value)
+    with pytest.raises(BoilerJuiceParseError):
+        parse_tank_ids('{"tanks": [{"name": "Garden"}]}')
+    assert parse_tank_ids("[]") == []
 
 
 def test_json_sign_in_error_is_an_auth_error() -> None:
@@ -692,6 +706,21 @@ def test_json_tank_picks_the_requested_id_from_a_list() -> None:
     assert reading.volume_litres == 2000
 
 
+def test_json_tank_singleton_with_a_different_id_raises() -> None:
+    with pytest.raises(BoilerJuiceParseError) as caught:
+        parse_tank_page('{"id": 654321, "percentage": 50}', "123456")
+
+    assert "not the one requested" in str(caught.value)
+    assert "654321" not in str(caught.value)
+
+
+def test_json_tank_singleton_without_an_id_is_the_requested_tank() -> None:
+    reading = parse_tank_page('[{"percentage": 50, "litres": 1000}]', "123456")
+
+    assert reading.tank_id == "123456"
+    assert reading.level_percentage == 50
+
+
 def test_json_tank_without_a_measurement_raises() -> None:
     with pytest.raises(BoilerJuiceParseError) as caught:
         parse_tank_page('{"id": 123456, "name": "Garden Tank"}', "123456")
@@ -714,15 +743,39 @@ def test_json_shape_carries_no_values() -> None:
         "will@together.agency",
         "998877",
         "Sycamore",
+        "email",
     ):
         assert secret not in serialised, f"the JSON shape leaked {secret!r}"
 
     assert parser.describe_json_shape(data) == {
         "is_json": True,
         "type": "object",
-        "keys": ["email", "name", "tanks"],
-        "nested": {"email": "string", "name": "string", "tanks": "list"},
+        "key_count": 3,
+        "recognised_keys": ["name", "tanks"],
+        "nested": {"name": "string", "tanks": "list"},
     }
+
+
+def test_json_shape_does_not_echo_identifier_keys() -> None:
+    """Account-specific values used as keys must not reach a diagnostic."""
+    data = {998877: {"email": "will@together.agency"}, "name": "Garden"}
+    serialised = json.dumps(parser.describe_json_shape(data))
+
+    assert "998877" not in serialised
+    assert "will@together.agency" not in serialised
+    assert "Garden" not in serialised
+    assert parser.describe_json_shape(data)["recognised_keys"] == ["name"]
+
+
+def test_json_shape_caps_the_recognised_keys_it_names() -> None:
+    payload = dict.fromkeys(parser._RECOGNISED_JSON_KEYS, 1)
+    payload["not_a_field"] = True
+    shape = parser.describe_json_shape(payload)
+
+    assert shape["key_count"] == len(parser._RECOGNISED_JSON_KEYS) + 1
+    assert len(shape["recognised_keys"]) == parser._MAX_SHAPE_KEYS
+    assert set(shape["recognised_keys"]) <= parser._RECOGNISED_JSON_KEYS
+    assert "not_a_field" not in json.dumps(shape)
 
 
 def test_broken_json_raises_without_quoting_the_body() -> None:
@@ -736,6 +789,9 @@ def test_looks_like_json_sign_in() -> None:
     assert parser.looks_like_json_sign_in(
         '{"error":"You need to sign in or sign up before continuing."}'
     )
+    assert parser.looks_like_json_sign_in(
+        '\ufeff{"error":"You need to sign in or sign up before continuing."}'
+    )
     assert parser.looks_like_json_sign_in("<html></html>") is False
     assert parser.looks_like_json_sign_in("{not-json") is False
     assert parser.looks_like_json_sign_in("[1, 2]") is False
@@ -746,7 +802,8 @@ def test_describe_json_shape_of_a_list_and_a_scalar() -> None:
         "is_json": True,
         "type": "list",
         "length": 3,
-        "item_keys": ["id", "name"],
+        "item_key_count": 2,
+        "recognised_item_keys": ["id", "name"],
     }
     assert parser.describe_json_shape(7) == {"is_json": True, "type": "number"}
     assert parser.describe_json_shape(None) == {"is_json": True, "type": "null"}


### PR DESCRIPTION
## Summary
- A non-empty JSON listing with no valid tank IDs now raises `BoilerJuiceParseError` instead of returning `[]`, so three bad polls cannot retire every tank device.
- A singleton tank document is accepted only when its ID matches the requested tank, or when it has no readable ID. `{"id":654321,"percentage":50}` is no longer published as tank `123456`.
- JSON shape diagnostics report counts and a capped allowlist of recognised field names, not arbitrary keys that can be tank IDs or email addresses.
- `_read_text` reads decoded stream chunks and stops as soon as the 4 MB cap is exceeded, so a runaway response is never fully materialised. A UTF-8 BOM on a JSON sign-in error no longer skips the login retry.

## Test plan
- [ ] CI: ruff, mypy, both Home Assistant test lanes
- [ ] Confirm `[{"name":"Garden"}]` lists as a parse error, not an empty account
- [ ] Confirm diagnostics and setup-failure reasons do not echo identifier keys
- [ ] After merge, cut `v2.0.0-beta.6` before promoting 2.0.0 to stable